### PR TITLE
Fix mkdocs serve Infinite Reload Loop

### DIFF
--- a/mkdocs_autoapi/autoapi.py
+++ b/mkdocs_autoapi/autoapi.py
@@ -87,6 +87,7 @@ def create_docs(
     root = Path(config["project_root"])
     exclude = config["exclude"]
     docs_dir = Path(config["docs_dir"])
+    command = config.get(key="command", default="serve")
     local_summary_path = docs_dir / "autoapi" / "summary.md"
     temp_summary_path = "autoapi/summary.md"
 
@@ -127,10 +128,11 @@ def create_docs(
         module_identifier = ".".join(module_path_parts)
 
         # Step 4.6
-        if not full_local_doc_path.parents[0].exists():
-            os.makedirs(full_local_doc_path.parents[0])
-        with open(full_local_doc_path, "w") as doc:
-            print(f"::: {module_identifier}", file=doc)
+        if command == "build":
+            if not full_local_doc_path.parents[0].exists():
+                os.makedirs(full_local_doc_path.parents[0])
+            with open(full_local_doc_path, "w") as doc:
+                print(f"::: {module_identifier}", file=doc)
         with mkdocs_autoapi.generate_files.open(full_temp_doc_path, "w") as doc:
             print(f"::: {module_identifier}", file=doc)
 
@@ -138,7 +140,8 @@ def create_docs(
         mkdocs_autoapi.generate_files.set_edit_path(full_temp_doc_path, file)
 
     # Step 5
-    with open(local_summary_path, "w") as local_nav_file:
-        local_nav_file.writelines(navigation.build_literate_nav())
+    if command == "build":
+        with open(local_summary_path, "w") as local_nav_file:
+            local_nav_file.writelines(navigation.build_literate_nav())
     with mkdocs_autoapi.generate_files.open(temp_summary_path, "w") as temp_nav_file:
         temp_nav_file.writelines(navigation.build_literate_nav())

--- a/mkdocs_autoapi/plugin.py
+++ b/mkdocs_autoapi/plugin.py
@@ -5,6 +5,7 @@ import collections
 from pathlib import Path
 import tempfile
 import urllib.parse
+from typing import Literal
 
 # third-party imports
 from jinja2 import Environment
@@ -34,6 +35,11 @@ class AutoApiPluginConfig(Config):
 
 class AutoApiPlugin(BasePlugin[AutoApiPluginConfig]):
     """Plugin logic definition."""
+
+    def on_startup(self, *, command: Literal['build', 'gh-deploy', 'serve'], dirty: bool) -> None:
+        """Add command to the configuration."""
+        self.config.update({"command": command})
+
 
     def on_files(self, files: Files, config: MkDocsConfig) -> Files:
         """Generate autoAPI documentation files.

--- a/mkdocs_autoapi/plugin.py
+++ b/mkdocs_autoapi/plugin.py
@@ -4,8 +4,8 @@
 import collections
 from pathlib import Path
 import tempfile
-import urllib.parse
 from typing import Literal
+import urllib.parse
 
 # third-party imports
 from jinja2 import Environment


### PR DESCRIPTION
This PR fixes a bug causing `mkdocs serve` to get caught in an infinite rebuilding loop when changes occur in a watched file. This bug was caused by the fact that I was writing local copies of API documentation files into `docs_dir`, which `mkdocs serve` also watches; thus, every time I reloaded the server, I was getting updates to `docs_dir` which triggered another reload. By ensuring that local copies of files are generated only for  `mkdocs build`, I avoid this issue.

Closes #11