### PR TITLE
Move from rglob to glob when evaluating excluded patterns

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -66,8 +66,8 @@ patterns are evaluated relative to [project_root](#setting-the-project-root).
     The following patterns are commonly used for virtual environments and are
     always excluded:
 
-    `./.venv/**/*.py` <br>
-    `./venv/**/*.py`
+    `venv/**/*.py` <br>
+    `.venv/**/*.py`
 
 !!! example
 

--- a/mkdocs_autoapi/autoapi.py
+++ b/mkdocs_autoapi/autoapi.py
@@ -49,7 +49,7 @@ def identify_files_to_documment(
     # Step 2
     if exclude:
         for pattern in exclude:
-            excluded_files = set(path.rglob(pattern=pattern))
+            excluded_files = set(path.glob(pattern=pattern))
             files_to_document = files_to_document.difference(excluded_files)
 
     # Step 3

--- a/mkdocs_autoapi/plugin.py
+++ b/mkdocs_autoapi/plugin.py
@@ -68,10 +68,10 @@ class AutoApiPlugin(BasePlugin[AutoApiPluginConfig]):
         config.update(self.config)
 
         # Step 2
-        if "**/venv/**/*.py" not in self.config.exclude:
-            self.config.exclude.append("**/venv/**/*.py")
-        if "**/.venv/**/*.py" not in self.config.exclude:
-            self.config.exclude.append("**/.venv/**/*.py")
+        if "venv/**/*.py" not in self.config.exclude:
+            self.config.exclude.append("venv/**/*.py")
+        if ".venv/**/*.py" not in self.config.exclude:
+            self.config.exclude.append(".venv/**/*.py")
 
         # Step 4
         with FilesEditor(


### PR DESCRIPTION
Build performance is significantly improved by using a non-recursive pattern evaluation method.