### PR TITLE
Fix CLI Bug

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -18,6 +18,15 @@ plugins:
 A common use case for this option is projects using the
 [src layout](https://packaging.python.org/en/latest/discussions/src-layout-vs-flat-layout/).
 
+!!! note "Notes"
+
+    Be sure to include the `project_root` directory in the `paths` configuration
+    for the `mkdocstrings` handler to ensure that the documentation is generated
+    relative to the correct directory.
+
+    If `project_root` contains `__init__.py`, this file will _not_ be included
+    in the API documentation.
+
 !!! example
 
     Consider a project with the following structure:
@@ -52,7 +61,11 @@ A common use case for this option is projects using the
       - ... other plugin configuration ...
       - mkdocs-autoapi:
           project_root: src # or /path/to/project/src
-      - mkdocstrings
+      - mkdocstrings:
+          handlers:
+            python:
+              paths:
+                - src
     ```
 
 ## Excluding Patterns

--- a/mkdocs_autoapi/autoapi.py
+++ b/mkdocs_autoapi/autoapi.py
@@ -116,6 +116,8 @@ def create_docs(
 
         # Step 4.3
         if module_path_parts[-1] == "__init__":
+            if len(module_path_parts) == 1:
+                continue
             module_path_parts = module_path_parts[:-1]
             doc_path = doc_path.with_name("index.md")
             full_local_doc_path = full_local_doc_path.with_name("index.md")

--- a/mkdocs_autoapi/generate_files/__init__.py
+++ b/mkdocs_autoapi/generate_files/__init__.py
@@ -3,7 +3,8 @@
 As I work through the build, I'll update the documentation for this module.
 """
 
-from .editor import FilesEditor
+from .nav import *
+from .editor import *
 
 
 def __getattr__(name: str):


### PR DESCRIPTION
Discovered that the plugin wasn't working when `mkdocs.yml` wasn't in the project's top-level directory. This PR fixes that bug.

Closes #17