### PR TITLE
Add Output Configuration Options

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -20,12 +20,16 @@ A common use case for this option is projects using the
 
 !!! note "Notes"
 
+    If a directory containing `__init__.py` is specified, then the directory
+    will be included in the relative path of its children. If not, then the
+    directory will not be included.
+
     Be sure to include the `project_root` directory in the `paths` configuration
     for the `mkdocstrings` handler to ensure that the documentation is generated
-    relative to the correct directory.
-
-    If `project_root` contains `__init__.py`, this file will _not_ be included
-    in the API documentation.
+    relative to the correct directory. If `project_root` does not contain
+    `__init__.py`, then `project_root` must be included. If it does, then the
+    parent directory of `project_root` must be included. For more information,
+    see the `mkdocstrings` [documentation](https://mkdocstrings.github.io/python/usage/#using-the-paths-option).
 
 !!! example
 
@@ -118,18 +122,56 @@ patterns are evaluated relative to [project_root](#setting-the-project-root).
       - mkdocstrings
     ```
 
-## Including API Documentation in Navigation
+## Controlling Output
 
-Auto-generated API documentation is saved to the `autoapi` directory. To include
-API documentation in your site's navigation, add the following configuration to
-`mkdocs.yml`:
+The plugin supports two configuration options for
+controlling output:
 
-```yaml title="mkdocs.yml"
-nav:
-  - ... other navigation sections ...
-  - API Reference: autoapi/
-  - ... other navigation sections ...
-```
+1. `generate_local_output` (`bool`): If `True`, then the plugin will generate
+   local copies of the Markdown files in `<docs_dir>/<output_dir>`. If `False`,
+   Markdown files will only be created in temp directory. Default is `False`.
+2. `output_dir` (`str`): The directory in which to save the generated Markdown
+   files. For local output, this directory is relative to `docs_dir`. Default
+   is `autoapi`.
+
+!!! example
+
+    Consider a project with the following structure:
+
+    ```tree
+    project/
+        docs/
+            index.md
+        module/
+            __init__.py
+            lorem.py
+            ipsum.py
+            dolor.py
+        second_module/
+            __init__.py
+            lorem.py
+            sit.py
+            amet.py
+        mkdocs.yml
+        README.md
+    ```
+
+    To generate local copies of the Markdown files in a directory named `api`,
+    add the following configuration to `mkdocs.yml`:
+
+    ```yaml title="mkdocs.yml"
+    nav:
+      - ... other navigation sections ...
+      - API Reference: api/
+      - ... other navigation sections ...
+    
+    plugins:
+      - ... other plugin configuration ...
+      - mkdocs-autoapi:
+          generate_local_output: True
+          output_dir: api
+      - mkdocstrings
+    ```
 
 ## Putting It All Together
 

--- a/mkdocs_autoapi/autoapi.py
+++ b/mkdocs_autoapi/autoapi.py
@@ -87,9 +87,10 @@ def create_docs(
     root = Path(config["project_root"])
     exclude = config["exclude"]
     docs_dir = Path(config["docs_dir"])
-    command = config.get(key="command", default="serve")
-    local_summary_path = docs_dir / "autoapi" / "summary.md"
-    temp_summary_path = "autoapi/summary.md"
+    output_dir = config["output_dir"]
+    generate_local_output = config["generate_local_output"]
+    local_summary_path = docs_dir / output_dir / "summary.md"
+    temp_summary_path = f"{output_dir}/summary.md"
 
     # Step 2
     navigation = nav.Nav()
@@ -106,7 +107,7 @@ def create_docs(
         except ValueError:
             module_path = Path("")
         doc_path = file.relative_to(file.parent).with_suffix(".md")
-        full_temp_doc_path = "autoapi" / module_path / doc_path
+        full_temp_doc_path = output_dir / module_path / doc_path
         full_local_doc_path = docs_dir / full_temp_doc_path
 
         # Step 4.2
@@ -130,7 +131,7 @@ def create_docs(
         module_identifier = ".".join(module_path_parts)
 
         # Step 4.6
-        if command == "build":
+        if generate_local_output:
             if not full_local_doc_path.parents[0].exists():
                 os.makedirs(full_local_doc_path.parents[0])
             with open(full_local_doc_path, "w") as doc:
@@ -142,7 +143,7 @@ def create_docs(
         mkdocs_autoapi.generate_files.set_edit_path(full_temp_doc_path, file)
 
     # Step 5
-    if command == "build":
+    if generate_local_output:
         with open(local_summary_path, "w") as local_nav_file:
             local_nav_file.writelines(navigation.build_literate_nav())
     with mkdocs_autoapi.generate_files.open(temp_summary_path, "w") as temp_nav_file:

--- a/mkdocs_autoapi/plugin.py
+++ b/mkdocs_autoapi/plugin.py
@@ -31,6 +31,8 @@ class AutoApiPluginConfig(Config):
 
     project_root = config_options.Dir(exists=True, default=".")
     exclude = config_options.ListOfItems(config_options.Type(str), default=[])
+    generate_local_output = config_options.Type(bool, default=False)
+    output_dir = config_options.Type(str, default="autoapi")
 
 
 class AutoApiPlugin(BasePlugin[AutoApiPluginConfig]):


### PR DESCRIPTION
This PR adds two new configuration options to the plugin.

1. `generate_local_output` - a boolean indicating whether copies of created files should be saved locally
2. `output_dir` - a string providing the name of the directory to which output should be saved; local copies are stored relative to `docs_dir`

Also included is logic to avoid an infinite loop on `mkdocs serve` when `generate_local_output` is `True` and files change after initial startup, by only creating new versions of existing files if there has been a change.

Closes #4 