### PR TITLE
Add Documentation Link + Badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # mkdocs-autoapi
 
+[![pypi version](https://img.shields.io/pypi/v/mkdocs-autoapi.svg)](https://pypi.org/project/mkdocs-autoapi/)
+[![docs](https://readthedocs.org/projects/mkdocs-autoapi/badge/?version=latest)](https://mkdocs-autoapi.readthedocs.io/en/latest/)
+
+
 ## Description
 
 `mkdocs-autoapi` is a MkDocs plugin that automatically generates API

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ python-legacy = ["mkdocstrings[python]>=0.19.0"]
 python = ["mkdocstrings[python-legacy]>=0.19.0"]
 
 [project.urls]
+Documentation = "https://mkdocs-autoapi.readthedocs.io/en/0.2.0/"
 Repository = "https://github.com/jcayers20/mkdocs-autoapi"
 Issues = "https://github.com/jcayers20/mkdocs-autoapi/issues"
 License = "https://github.com/jcayers20/mkdocs-autoapi/blob/main/LICENSE"


### PR DESCRIPTION
Added a link to the documentation to `pyproject.toml` so that the PyPI page for the package will have a link to its ReadTheDocs page (note that I linked to a version-specific page that doesn't yet exist so I'll need to remember to do that once I've gotten 0.2.0 into main). I also added PyPI and ReadTheDocs badges to the README file so that viewers of the GitHub repo can quickly access them.