### PR TITLE
Refactor and Add Config Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ plugins:
   - mkdocstrings
 ```
 
-### Excluding Patterns
+### Ignoring Patterns
 
-You can exclude files and directories from the documentation by specifying a
-value in the `exclude` configuration option. This option accepts a list of
-glob patterns. Note that the following patterns are always excluded:
+You can ignore files and directories from the documentation by specifying a
+value in the `autoapi_ignore` configuration option. This option accepts a list
+of glob patterns. Note that the following patterns are always ignored:
 
 * `**/.venv/**/`
 * `**/venv/**/`
@@ -85,14 +85,14 @@ project/
     README.md
 ```
 
-To exclude all files named `lorem.py`, you can add the following configuration
+To ignore all files named `lorem.py`, you can add the following configuration
 to your `mkdocs.yml` file:
 
 ```yaml
 plugins:
   - ... other plugin configuration ...
   - mkdocs-autoapi:
-      exclude:
+      autoapi_ignore:
         - "**/lorem.py"
   - mkdocstrings
 ```

--- a/README.md
+++ b/README.md
@@ -45,13 +45,13 @@ plugins:
 
 By default, the plugin will use the current working directory as the project
 root. If you would like to use a different directory, you can specify a value
-in the `project_root` configuration option:
+in the `autoapi_dir` configuration option:
 
 ```yaml
 plugins:
   - ... other plugin configuration ...
   - mkdocs-autoapi:
-      project_root: /path/to/project/root
+      autoapi_dir: /path/to/autoapi/dir
   - mkdocstrings
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ of glob patterns. Note that the following patterns are always ignored:
 * `**/.venv/**/`
 * `**/venv/**/`
 
+Likewise, the `autoapi_file_patterns` configuration option allows for control of
+which files are included in the API reference. This option also accepts a list
+of glob patterns which are evaluated (recursively) relative to `autoapi_dir`. By
+default, all files with `.py` and `.pyi` extensions are included.
+
 As an example, suppose your project has the following structure:
 
 ```tree
@@ -94,6 +99,8 @@ plugins:
   - mkdocs-autoapi:
       autoapi_ignore:
         - "**/lorem.py"
+      autoapi_file_patterns:
+        - "*.py"
   - mkdocstrings
 ```
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ plugins:
   - mkdocstrings
 ```
 
-### Ignoring Patterns
+### Including and Ignoring Patterns
 
 You can ignore files and directories from the documentation by specifying a
 value in the `autoapi_ignore` configuration option. This option accepts a list
@@ -104,16 +104,45 @@ plugins:
   - mkdocstrings
 ```
 
-### Including API Documentation in Navigation
+## Disabling API Documentation Generation
 
-To include the API documentation created by the plugin in your site's
-navigation, you can add the following configuration to your `mkdocs.yml` file:
+To disable API documentation generation, set the `autoapi_generate_api_docs`
+configuration option to `False`. This is useful when transitioning to manual
+documentation or when the API documentation is not needed.
+
+## Including API Documentation in Navigation
+
+The inclusion of API documentation in the navigation can be controlled via the
+configuration option `autoapi_add_nav_entry`. This option accepts either a
+boolean value or a string. Behavior is as follows:
+
+* If `True`, then a section named "API Reference" will be added to the end of
+the navigation.
+* If `False`, then no section for the API documentation will be added. In this
+case, a manual link to the API documentation can be added to the navigation.
+* If a string, then a section with the specified name will be added to the end
+of the navigation.
+
+Example: To include the API documentation in the navigation under the section
+"Reference", add the following configuration to `mkdocs.yml`:
+
+```yaml
+plugins:
+  - ... other plugin configuration ...
+  - mkdocs-autoapi:
+      autoapi_add_nav_entry: Reference
+  - mkdocstrings
+```
+
+Example: To disable the automatic addition of the API documentation to the
+navigation and add a manual link to the API documentation, add the following
+configuration to `mkdocs.yml`:
 
 ```yaml
 nav:
-  - ... other navigation sections ...
-  - API Reference: autoapi/
-  - ... other navigation sections ...
+  - ... other navigation configuration ...
+  - API: autoapi/ # target should be `autoapi_root`
+  - ... other navigation configuration ...
 ```
 
 More information on navigation configuration can be found in the

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -57,7 +57,7 @@ A common use case for this option is projects using the
 
     For this project, it may or may not be desirable to include the `tools`
     directory in the API reference and we probably don't want to include
-    the `*.py` files in the top-level directory. To exclude these items, we can
+    the `*.py` files in the top-level directory. To ignore these items, we can
     set `autoapi_dir` to `src`:
 
     ```yaml title="mkdocs.yml"
@@ -72,16 +72,16 @@ A common use case for this option is projects using the
                 - src
     ```
 
-## Excluding Patterns
+## Ignoring Patterns
 
-The `exclude` configuration option allows for exclusion of files matching the
-specified pattern(s). This option accepts a list of
-[glob](https://man7.org/linux/man-pages/man7/glob.7.html) patterns. These
-patterns are evaluated relative to [autoapi_dir](#setting-the-project-root).
+The `autoapi_ignore` configuration option allows for exclusion of files matching
+the specified pattern(s). This option accepts a list of [glob](https://man7.org/linux/man-pages/man7/glob.7.html)
+patterns. These patterns are evaluated relative to
+[autoapi_dir](#setting-the-project-root).
 
 !!! note
     The following patterns are commonly used for virtual environments and are
-    always excluded:
+    always ignored:
 
     `venv/**/*.py` <br>
     `.venv/**/*.py`
@@ -108,15 +108,15 @@ patterns are evaluated relative to [autoapi_dir](#setting-the-project-root).
         README.md
     ```
 
-    Suppose we want to exclude all files named `lorem.py` and all files
-    in the `second_module` directory. We can add the following configuration to
+    Suppose we want to ignore all files named `lorem.py` and all files in the
+    `second_module` directory. We can add the following configuration to
     `mkdocs.yml`:
 
     ```yaml title="mkdocs.yml"
     plugins:
       - ... other plugin configuration ...
       - mkdocs-autoapi:
-          exclude:
+          autoapi_ignore:
             - **/lorem.py
             - second_module/**/*.py
       - mkdocstrings

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -130,7 +130,7 @@ controlling output:
 1. `autoapi_keep_files` (`bool`): If `True`, then the plugin will generate local
     copies of the Markdown files in `<docs_dir>/<output_dir>`. If `False`,
     Markdown files will only be created in temp directory. Default is `False`.
-2. `output_dir` (`str`): The directory in which to save the generated Markdown
+2. `autoapi_root` (`str`): The directory in which to save the generated Markdown
    files. For local output, this directory is relative to `docs_dir`. Default
    is `autoapi`.
 
@@ -169,7 +169,7 @@ controlling output:
       - ... other plugin configuration ...
       - mkdocs-autoapi:
           autoapi_keep_files: True
-          output_dir: api
+          autoapi_root: api
       - mkdocstrings
     ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -135,7 +135,7 @@ The plugin supports two configuration options for
 controlling output:
 
 1. `autoapi_keep_files` (`bool`): If `True`, then the plugin will generate local
-    copies of the Markdown files in `<docs_dir>/<output_dir>`. If `False`,
+    copies of the Markdown files in `<docs_dir>/<autoapi_root>`. If `False`,
     Markdown files will only be created in temp directory. Default is `False`.
 2. `autoapi_root` (`str`): The directory in which to save the generated Markdown
    files. For local output, this directory is relative to `docs_dir`. Default
@@ -167,11 +167,6 @@ controlling output:
     add the following configuration to `mkdocs.yml`:
 
     ```yaml title="mkdocs.yml"
-    nav:
-      - ... other navigation sections ...
-      - API Reference: api/
-      - ... other navigation sections ...
-
     plugins:
       - ... other plugin configuration ...
       - mkdocs-autoapi:
@@ -185,6 +180,50 @@ controlling output:
 To disable API documentation generation, set the `autoapi_generate_api_docs`
 configuration option to `False`. This is useful when transitioning to manual
 documentation or when the API documentation is not needed.
+
+## Including API Documentation in Navigation
+
+The inclusion of API documentation in the navigation can be controlled via the
+configuration option `autoapi_add_nav_entry`. This option accepts either a
+boolean value or a string. Behavior is as follows:
+
+* If `True`, then a section named "API Reference" will be added to the end of
+the navigation.
+* If `False`, then no section for the API documentation will be added. In this
+case, a manual link to the API documentation can be added to the navigation.
+* If a string, then a section with the specified name will be added to the end
+of the navigation.
+
+!!! example
+
+    To include the API documentation in the navigation under the section
+    "Reference", add the following configuration to `mkdocs.yml`:
+
+    ```yaml title="mkdocs.yml"
+    plugins:
+      - ... other plugin configuration ...
+      - mkdocs-autoapi:
+          autoapi_add_nav_entry: Reference
+      - mkdocstrings
+    ```
+
+!!! example
+
+    To disable automatic addition of the API documentation to the navigation and
+    instead add a manual link, add the following configuration to `mkdocs.yml`:
+
+    ```yaml title="mkdocs.yml"
+    nav:
+      - Home: index.md
+      - API: autoapi/ # target should be `autoapi_root`
+      - Examples: examples.md
+
+    plugins:
+      - ... other plugin configuration ...
+      - mkdocs-autoapi:
+          autoapi_add_nav_entry: False
+      - mkdocstrings
+    ```
 
 
 ## Putting It All Together
@@ -218,7 +257,6 @@ documentation or when the API documentation is not needed.
 
     nav:
       - Home: index.md
-      - API Reference: autoapi/
 
     plugins:
       - search

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -4,14 +4,14 @@
 
 By default, the plugin considers the directory containing `mkdocs.yml` the
 project root directory. To use a different directory, specify the directory
-path in the `project_root` configuration option. The path can be absolute or
+path in the `autoapi_dir` configuration option. The path can be absolute or
 relative to the directory containing `mkdocs.yml`.
 
 ```yaml
 plugins:
   - ... other plugin configuration ...
   - mkdocs-autoapi:
-      project_root: path/to/project/root
+      autoapi_dir: path/to/autoapi/dir
   - mkdocstrings
 ```
 
@@ -24,11 +24,11 @@ A common use case for this option is projects using the
     will be included in the relative path of its children. If not, then the
     directory will not be included.
 
-    Be sure to include the `project_root` directory in the `paths` configuration
+    Be sure to include the `autoapi_dir` directory in the `paths` configuration
     for the `mkdocstrings` handler to ensure that the documentation is generated
-    relative to the correct directory. If `project_root` does not contain
-    `__init__.py`, then `project_root` must be included. If it does, then the
-    parent directory of `project_root` must be included. For more information,
+    relative to the correct directory. If `autoapi_dir` does not contain
+    `__init__.py`, then `autoapi_dir` must be included. If it does, then the
+    parent directory of `autoapi_dir` must be included. For more information,
     see the `mkdocstrings` [documentation](https://mkdocstrings.github.io/python/usage/#using-the-paths-option).
 
 !!! example
@@ -58,13 +58,13 @@ A common use case for this option is projects using the
     For this project, it may or may not be desirable to include the `tools`
     directory in the API reference and we probably don't want to include
     the `*.py` files in the top-level directory. To exclude these items, we can
-    set `project_root` to `src`:
+    set `autoapi_dir` to `src`:
 
     ```yaml title="mkdocs.yml"
     plugins:
       - ... other plugin configuration ...
       - mkdocs-autoapi:
-          project_root: src # or /path/to/project/src
+          autoapi_dir: src # or /path/to/project/src
       - mkdocstrings:
           handlers:
             python:
@@ -77,7 +77,7 @@ A common use case for this option is projects using the
 The `exclude` configuration option allows for exclusion of files matching the
 specified pattern(s). This option accepts a list of
 [glob](https://man7.org/linux/man-pages/man7/glob.7.html) patterns. These
-patterns are evaluated relative to [project_root](#setting-the-project-root).
+patterns are evaluated relative to [autoapi_dir](#setting-the-project-root).
 
 !!! note
     The following patterns are commonly used for virtual environments and are
@@ -164,7 +164,7 @@ controlling output:
       - ... other navigation sections ...
       - API Reference: api/
       - ... other navigation sections ...
-    
+
     plugins:
       - ... other plugin configuration ...
       - mkdocs-autoapi:
@@ -211,5 +211,3 @@ controlling output:
       - mkdocs-autoapi
       - mkdocstrings
     ```
-
-

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -180,6 +180,13 @@ controlling output:
       - mkdocstrings
     ```
 
+## Disabling API Documentation Generation
+
+To disable API documentation generation, set the `autoapi_generate_api_docs`
+configuration option to `False`. This is useful when transitioning to manual
+documentation or when the API documentation is not needed.
+
+
 ## Putting It All Together
 
 !!! example

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -127,9 +127,9 @@ patterns. These patterns are evaluated relative to
 The plugin supports two configuration options for
 controlling output:
 
-1. `generate_local_output` (`bool`): If `True`, then the plugin will generate
-   local copies of the Markdown files in `<docs_dir>/<output_dir>`. If `False`,
-   Markdown files will only be created in temp directory. Default is `False`.
+1. `autoapi_keep_files` (`bool`): If `True`, then the plugin will generate local
+    copies of the Markdown files in `<docs_dir>/<output_dir>`. If `False`,
+    Markdown files will only be created in temp directory. Default is `False`.
 2. `output_dir` (`str`): The directory in which to save the generated Markdown
    files. For local output, this directory is relative to `docs_dir`. Default
    is `autoapi`.
@@ -168,7 +168,7 @@ controlling output:
     plugins:
       - ... other plugin configuration ...
       - mkdocs-autoapi:
-          generate_local_output: True
+          autoapi_keep_files: True
           output_dir: api
       - mkdocstrings
     ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -72,12 +72,17 @@ A common use case for this option is projects using the
                 - src
     ```
 
-## Ignoring Patterns
+## Including and Ignoring Patterns
 
 The `autoapi_ignore` configuration option allows for exclusion of files matching
 the specified pattern(s). This option accepts a list of [glob](https://man7.org/linux/man-pages/man7/glob.7.html)
 patterns. These patterns are evaluated relative to
 [autoapi_dir](#setting-the-project-root).
+
+Likewise, the `autoapi_file_patterns` configuration option allows for control of
+which files are included in the API reference. This option also accepts a list
+of glob patterns which are evaluated (recursively) relative to `autoapi_dir`. By
+default, all files with `.py` and `.pyi` extensions are included.
 
 !!! note
     The following patterns are commonly used for virtual environments and are
@@ -119,6 +124,8 @@ patterns. These patterns are evaluated relative to
           autoapi_ignore:
             - **/lorem.py
             - second_module/**/*.py
+          autoapi_file_patterns:
+            - *.py # ignoring .pyi to improve performance since no stubs present
       - mkdocstrings
     ```
 

--- a/mkdocs_autoapi/autoapi.py
+++ b/mkdocs_autoapi/autoapi.py
@@ -89,7 +89,7 @@ def create_docs(
     autoapi_ignore = config["autoapi_ignore"]
     docs_dir = Path(config["docs_dir"])
     output_dir = config["output_dir"]
-    generate_local_output = config["generate_local_output"]
+    autoapi_keep_files = config["autoapi_keep_files"]
     local_summary_path = docs_dir / output_dir / "summary.md"
     temp_summary_path = f"{output_dir}/summary.md"
 
@@ -139,7 +139,7 @@ def create_docs(
         module_identifier = ".".join(module_path_parts)
 
         # Step 4.6
-        if generate_local_output:
+        if autoapi_keep_files:
             if not full_local_doc_path.parents[0].exists():
                 os.makedirs(full_local_doc_path.parents[0])
 
@@ -164,7 +164,7 @@ def create_docs(
         mkdocs_autoapi.generate_files.set_edit_path(full_temp_doc_path, file)
 
     # Step 5
-    if generate_local_output:
+    if autoapi_keep_files:
         try:
             with open(local_summary_path, "r+") as local_nav_file:
                 old_content = local_nav_file.read()

--- a/mkdocs_autoapi/autoapi.py
+++ b/mkdocs_autoapi/autoapi.py
@@ -83,7 +83,7 @@ def create_docs(
         None.
     """
     # Step 1
-    root = Path(config["project_root"])
+    autoapi_dir = Path(config["autoapi_dir"])
     exclude = config["exclude"]
     docs_dir = Path(config["docs_dir"])
     output_dir = config["output_dir"]
@@ -95,19 +95,21 @@ def create_docs(
     navigation = nav.Nav()
 
     # Step 3
-    files_to_document = identify_files_to_document(path=root, exclude=exclude)
+    files_to_document = identify_files_to_document(
+        path=autoapi_dir, exclude=exclude
+    )
 
     # Step 4
-    if (root / "__init__.py").exists():
-        root = root.parent
+    if (autoapi_dir / "__init__.py").exists():
+        autoapi_dir = autoapi_dir.parent
 
     # Step 4
     for file in sorted(files_to_document):
         # Step 4.1
         try:
-            module_path = file.relative_to(root.resolve()).parent.with_suffix(
-                ""
-            )
+            module_path = file.relative_to(
+                autoapi_dir.resolve()
+            ).parent.with_suffix("")
         except ValueError:
             module_path = Path("")
         doc_path = file.relative_to(file.parent).with_suffix(".md")

--- a/mkdocs_autoapi/autoapi.py
+++ b/mkdocs_autoapi/autoapi.py
@@ -88,10 +88,10 @@ def create_docs(
     autoapi_dir = Path(config["autoapi_dir"])
     autoapi_ignore = config["autoapi_ignore"]
     docs_dir = Path(config["docs_dir"])
-    output_dir = config["output_dir"]
+    autoapi_root = config["autoapi_root"]
     autoapi_keep_files = config["autoapi_keep_files"]
-    local_summary_path = docs_dir / output_dir / "summary.md"
-    temp_summary_path = f"{output_dir}/summary.md"
+    local_summary_path = docs_dir / autoapi_root / "summary.md"
+    temp_summary_path = f"{autoapi_root}/summary.md"
 
     # Step 2
     navigation = nav.Nav()
@@ -115,7 +115,7 @@ def create_docs(
         except ValueError:
             module_path = Path("")
         doc_path = file.relative_to(file.parent).with_suffix(".md")
-        full_temp_doc_path = output_dir / module_path / doc_path
+        full_temp_doc_path = autoapi_root / module_path / doc_path
         full_local_doc_path = docs_dir / full_temp_doc_path
 
         # Step 4.2

--- a/mkdocs_autoapi/autoapi.py
+++ b/mkdocs_autoapi/autoapi.py
@@ -18,38 +18,40 @@ from mkdocs_autoapi.generate_files import nav
 
 def identify_files_to_document(
     path: Path,
-    exclude: Optional[Iterable[str]] = None,
+    autoapi_ignore: Optional[Iterable[str]] = None,
 ) -> Set[Path]:
     """Get a set of all Python files for which documentation must be generated.
 
     This function finds all Python files located in `path`, then removes any
-    that match at least one member of `exclude`.
+    that match at least one member of `autoapi_ignore`.
 
     Steps:
         1.  Get set of all Python files in `path`.
-        2.  For each pattern in `exclude`, get set of all files matching the
-            pattern and reduce the set of Python files to only those files that
-            *do not* match the pattern.
+        2.  For each pattern in `autoapi_ignore`, get set of all files matching
+            the pattern and reduce the set of Python files to only those files
+            that *do not* match the pattern.
         3.  Return the final set of files to include.
 
     Args:
         path:
             The path to search.
-        exclude:
-            The patterns to exclude.
+        autoapi_ignore:
+            The patterns to autoapi_ignore.
 
     Returns (Set[pathlib.Path]):
         The set of all Python files in `path` that *do not* match any member of
-        `exclude`.
+        `autoapi_ignore`.
     """
     # Step 1
     files_to_document = set(path.rglob(pattern="*.py"))
 
     # Step 2
-    if exclude:
-        for pattern in exclude:
-            excluded_files = set(path.glob(pattern=pattern))
-            files_to_document = files_to_document.difference(excluded_files)
+    if autoapi_ignore:
+        for pattern in autoapi_ignore:
+            autoapi_ignored_files = set(path.glob(pattern=pattern))
+            files_to_document = files_to_document.difference(
+                autoapi_ignored_files
+            )
 
     # Step 3
     return {p.resolve() for p in files_to_document}
@@ -84,7 +86,7 @@ def create_docs(
     """
     # Step 1
     autoapi_dir = Path(config["autoapi_dir"])
-    exclude = config["exclude"]
+    autoapi_ignore = config["autoapi_ignore"]
     docs_dir = Path(config["docs_dir"])
     output_dir = config["output_dir"]
     generate_local_output = config["generate_local_output"]
@@ -96,7 +98,7 @@ def create_docs(
 
     # Step 3
     files_to_document = identify_files_to_document(
-        path=autoapi_dir, exclude=exclude
+        path=autoapi_dir, autoapi_ignore=autoapi_ignore
     )
 
     # Step 4

--- a/mkdocs_autoapi/plugin.py
+++ b/mkdocs_autoapi/plugin.py
@@ -28,6 +28,10 @@ class AutoApiPluginConfig(Config):
     """Configuration options for plugin."""
 
     autoapi_dir = config_options.Dir(exists=True, default=".")
+    autoapi_file_patterns = config_options.ListOfItems(
+        config_options.Type(str),
+        default=["*.py", "*.pyi"],
+    )
     autoapi_ignore = config_options.ListOfItems(
         config_options.Type(str), default=[]
     )

--- a/mkdocs_autoapi/plugin.py
+++ b/mkdocs_autoapi/plugin.py
@@ -17,7 +17,7 @@ from mkdocs.structure.nav import Navigation, Section
 from mkdocs.structure.pages import Page
 
 # local imports
-from mkdocs_autoapi.autoapi import create_docs
+from mkdocs_autoapi.autoapi import add_autoapi_nav_entry, create_docs
 from mkdocs_autoapi.generate_files.editor import FilesEditor
 from mkdocs_autoapi.literate_nav import resolve
 from mkdocs_autoapi.section_index import rewrite
@@ -37,6 +37,7 @@ class AutoApiPluginConfig(Config):
     )
     autoapi_keep_files = config_options.Type(bool, default=False)
     autoapi_generate_api_docs = config_options.Type(bool, default=True)
+    autoapi_add_nav_entry = config_options.Type((str, bool), default=True)
     autoapi_root = config_options.Type(str, default="autoapi")
 
 
@@ -88,10 +89,12 @@ class AutoApiPlugin(BasePlugin[AutoApiPluginConfig]):
             directory=self._dir.name,
         ) as editor:
             try:
+                print(f"Nav before: {config.nav}")
                 if self.config.autoapi_generate_api_docs:
-                    create_docs(
-                        config=config,
-                    )
+                    create_docs(config=config)
+                elif self.config.autoapi_add_nav_entry:
+                    add_autoapi_nav_entry(config=config)
+                print(f"Nav before: {config.nav}")
             except Exception as e:
                 raise PluginError(str(e))
 
@@ -121,7 +124,6 @@ class AutoApiPlugin(BasePlugin[AutoApiPluginConfig]):
 
     def on_nav(self, nav: Navigation, config, files) -> Navigation:
         """Apply plugin-specific transformations to the navigation."""
-        print(f"Nav starting: {nav}")
         todo = collections.deque((nav.items,))
         while todo:
             items = todo.popleft()

--- a/mkdocs_autoapi/plugin.py
+++ b/mkdocs_autoapi/plugin.py
@@ -28,7 +28,9 @@ class AutoApiPluginConfig(Config):
     """Configuration options for plugin."""
 
     autoapi_dir = config_options.Dir(exists=True, default=".")
-    exclude = config_options.ListOfItems(config_options.Type(str), default=[])
+    autoapi_ignore = config_options.ListOfItems(
+        config_options.Type(str), default=[]
+    )
     generate_local_output = config_options.Type(bool, default=False)
     output_dir = config_options.Type(str, default="autoapi")
 
@@ -47,8 +49,8 @@ class AutoApiPlugin(BasePlugin[AutoApiPluginConfig]):
 
         Steps:
             1.  Create a temporary directory to store the generated files.
-            2.  Exclude the virtual environment from the documentation if it is
-                not already excluded.
+            2.  Ignore the virtual environment from the documentation if it is
+                not already ignored.
             3.  Create the autoAPI documentation files.
             4.  Store the paths of the generated files.
             5.  Return the updated files object.
@@ -69,10 +71,10 @@ class AutoApiPlugin(BasePlugin[AutoApiPluginConfig]):
         config.update(self.config)
 
         # Step 2
-        if "venv/**/*.py" not in self.config.exclude:
-            self.config.exclude.append("venv/**/*.py")
-        if ".venv/**/*.py" not in self.config.exclude:
-            self.config.exclude.append(".venv/**/*.py")
+        if "venv/**/*.py" not in self.config.autoapi_ignore:
+            self.config.autoapi_ignore.append("venv/**/*.py")
+        if ".venv/**/*.py" not in self.config.autoapi_ignore:
+            self.config.autoapi_ignore.append(".venv/**/*.py")
 
         # Step 4
         with FilesEditor(

--- a/mkdocs_autoapi/plugin.py
+++ b/mkdocs_autoapi/plugin.py
@@ -32,7 +32,7 @@ class AutoApiPluginConfig(Config):
         config_options.Type(str), default=[]
     )
     autoapi_keep_files = config_options.Type(bool, default=False)
-    output_dir = config_options.Type(str, default="autoapi")
+    autoapi_root = config_options.Type(str, default="autoapi")
 
 
 class AutoApiPlugin(BasePlugin[AutoApiPluginConfig]):

--- a/mkdocs_autoapi/plugin.py
+++ b/mkdocs_autoapi/plugin.py
@@ -31,7 +31,7 @@ class AutoApiPluginConfig(Config):
     autoapi_ignore = config_options.ListOfItems(
         config_options.Type(str), default=[]
     )
-    generate_local_output = config_options.Type(bool, default=False)
+    autoapi_keep_files = config_options.Type(bool, default=False)
     output_dir = config_options.Type(str, default="autoapi")
 
 

--- a/mkdocs_autoapi/plugin.py
+++ b/mkdocs_autoapi/plugin.py
@@ -27,7 +27,7 @@ from mkdocs_autoapi.section_index.section_page import SectionPage
 class AutoApiPluginConfig(Config):
     """Configuration options for plugin."""
 
-    project_root = config_options.Dir(exists=True, default=".")
+    autoapi_dir = config_options.Dir(exists=True, default=".")
     exclude = config_options.ListOfItems(config_options.Type(str), default=[])
     generate_local_output = config_options.Type(bool, default=False)
     output_dir = config_options.Type(str, default="autoapi")

--- a/mkdocs_autoapi/plugin.py
+++ b/mkdocs_autoapi/plugin.py
@@ -89,12 +89,10 @@ class AutoApiPlugin(BasePlugin[AutoApiPluginConfig]):
             directory=self._dir.name,
         ) as editor:
             try:
-                print(f"Nav before: {config.nav}")
                 if self.config.autoapi_generate_api_docs:
                     create_docs(config=config)
                 elif self.config.autoapi_add_nav_entry:
                     add_autoapi_nav_entry(config=config)
-                print(f"Nav before: {config.nav}")
             except Exception as e:
                 raise PluginError(str(e))
 


### PR DESCRIPTION
After a review of the configuration options available in `sphinx-autoapi`, I made the following changes and additions to the config  options for this project:
* Renamed options
    * `project_root` => `autoapi_dir`
    * `exclude` => `autoapi_ignore`
    * `generate_local_files` => `autoapi_keep_files`
    * `output_dir` => `autoapi_root`
* Added options
    * `autoapi_file_patterns`  - rather than always including files ending with `.py`, the user can now provide pattern(s) to include
    * `autoapi_generate_local_docs` - Users now can control whether new auto-generated files are produced (turning off is useful for projects that want to transition to manual docs)
    * `autoapi_add_nav_entry` - Users can choose to automatically have a section for the API docs added at the end of the navigation

I'm sure there will be opportunities for improvement and/or bugs down the line, but I've confirmed these configuration options work as I expect them to on simple projects so I feel comfortable including them in v0.3.

Closes #31 
Closes #37 