### PR TITLE
Add VBA Support

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -20,10 +20,10 @@ In addition, you must install an `mkdocstrings`
 programming language.
 
 !!! note
-    Currently, only Python handlers are supported. Support for additional
+    Currently, Python and VBA handlers are supported. Support for additional
     programming languages (e.g., C, shell) is planned for future releases.
     See [Installation via `pip`](#installation-via-pip) for more details on how
-    to install the Python handler along with `mkdocs-autoapi`.
+    to install handlers along with `mkdocs-autoapi`.
 
 ### Installation via `pip`
 
@@ -33,7 +33,7 @@ To install `mkdocs-autoapi` with `pip`:
 pip install mkdocs-autoapi
 ```
 
-Extras are provided to support installation of `mkdocstrings``s Python handler:
+Extras are provided to support installation of `mkdocstrings` handlers:
 
 ```bash
 pip install mkdocs-autoapi[python] # new Python handler
@@ -41,6 +41,10 @@ pip install mkdocs-autoapi[python] # new Python handler
 
 ```bash
 pip install mkdocs-autoapi[python-legacy] # legacy Python handler
+```
+
+```bash
+pip install mkdocs-autoapi[vba] # VBA handler
 ```
 
 ## Basic Usage

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -88,8 +88,8 @@ default, all files with `.py` and `.pyi` extensions are included.
     The following patterns are commonly used for virtual environments and are
     always ignored:
 
-    `venv/**/*.py` <br>
-    `.venv/**/*.py`
+    `venv/**/*` <br>
+    `.venv/**/*`
 
 !!! example
 

--- a/mkdocs_autoapi/plugin.py
+++ b/mkdocs_autoapi/plugin.py
@@ -159,10 +159,10 @@ class AutoApiPlugin(BasePlugin[AutoApiPluginConfig]):
         config.update(self.config)
 
         # Step 2
-        if "venv/**/*.py" not in self.config.autoapi_ignore:
-            self.config.autoapi_ignore.append("venv/**/*.py")
-        if ".venv/**/*.py" not in self.config.autoapi_ignore:
-            self.config.autoapi_ignore.append(".venv/**/*.py")
+        if "venv/**/*" not in self.config.autoapi_ignore:
+            self.config.autoapi_ignore.append("venv/**/*")
+        if ".venv/**/*" not in self.config.autoapi_ignore:
+            self.config.autoapi_ignore.append(".venv/**/*")
 
         # Step 4
         with FilesEditor(

--- a/mkdocs_autoapi/plugin.py
+++ b/mkdocs_autoapi/plugin.py
@@ -12,7 +12,7 @@ from typing import Optional
 from jinja2 import Environment
 from mkdocs.config import Config, config_options
 from mkdocs.config.defaults import MkDocsConfig
-from mkdocs.exceptions import PluginError
+from mkdocs.exceptions import ConfigurationError, PluginError
 from mkdocs.plugins import BasePlugin
 from mkdocs.structure.files import Files
 from mkdocs.structure.nav import Navigation, Section
@@ -86,7 +86,7 @@ class AutoApiPlugin(BasePlugin[AutoApiPluginConfig]):
             # Step 2a.2
             if not mkdocstrings_configuration.enabled:
                 logger.warning(
-                    msg="mkdocstrings is not enabled.\n    HINT: Set `enabled: True` in mkdocstrings configuration."  # noqa: E501
+                    msg="mkdocstrings is not enabled.\n    HINT: Set `enabled: True` in mkdocstrings configuration."
                 )
 
             # Step 2a.3
@@ -120,13 +120,20 @@ class AutoApiPlugin(BasePlugin[AutoApiPluginConfig]):
                         start=mkdocs_yml_dir,
                     ).replace("\\", "/")
                     logger.warning(
-                        msg=f'AutoAPI directory not found in paths for `mkdocstrings` handler "{handler}".\n    HINT: Add "{relative_autoapi_dir}" to the `paths` list in the `mkdocstrings` handler configuration.'  # noqa: E501
+                        msg=f'AutoAPI directory not found in paths for `mkdocstrings` handler "{handler}".\n    HINT: Add "{relative_autoapi_dir}" to the `paths` list in the `mkdocstrings` handler configuration.'
                     )
+
+            # Step 2a.6
+            default_handler = mkdocstrings_configuration.default_handler
+            if default_handler not in ["python", "vba"]:
+                raise ConfigurationError(
+                    f"mkdocstrings default handler must be one of ['python', 'python-legacy', 'vba'], not: {handler}"
+                )
 
         # Step 2b
         else:
             logger.warning(
-                msg="mkdocstrings is not included in mkdocs configuration.\n    HINT: Add `mkdocstrings` to the `plugins` list in mkdocs configuration file."  # noqa: E501
+                msg="mkdocstrings is not included in mkdocs configuration.\n    HINT: Add `mkdocstrings` to the `plugins` list in mkdocs configuration file."
             )
 
         # Step 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ mkdocs-autoapi = 'mkdocs_autoapi.plugin:AutoApiPlugin'
 [project.optional-dependencies]
 python-legacy = ["mkdocstrings[python-legacy]>=0.19.0"]
 python = ["mkdocstrings[python]>=0.19.0"]
+vba = ["mkdocstrings-vba>=0.0.10"]
 
 [project.urls]
 Changelog = "https://github.com/jcayers20/mkdocs-autoapi/blob/main/CHANGELOG.md"


### PR DESCRIPTION
This PR contains a first pass at enabling support for `mkdocstrings`'s [VBA handler](https://github.com/mkdocstrings/vba). I've confirmed that it works with the [basic example](https://github.com/mkdocstrings/vba/tree/master/examples/example1), but I've never programmed in VBA before so I don't know how to test anything beyond that.

Closes #53