### PR TITLE
Release 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.1 - 2025-04-01
+
+[View Changes on GitHub](https://github.com/jcayers20/mkdocs-autoapi/compare/0.4.0...0.4.1)
+
+### Bug Fixes
+
+- Fixed a bug where the plugin would crash if `nav` is not defined in
+`mkdocs.yml` but `autoapi_add_nav_entry` is not `False` (thanks @k4lizen for the
+catch!)
+
 ## 0.4.0 - 2025-02-05
 
 [View Changes on GitHub](https://github.com/jcayers20/mkdocs-autoapi/compare/0.3.2...0.4.0)

--- a/mkdocs_autoapi/autoapi.py
+++ b/mkdocs_autoapi/autoapi.py
@@ -105,6 +105,8 @@ def add_autoapi_nav_entry(
         autoapi_section_title = config["autoapi_add_nav_entry"]
 
     # Step 3
+    if not config.nav:
+        config.nav = []
     config.nav.append({autoapi_section_title: autoapi_root_ref})
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mkdocs-autoapi"
-version = "0.3.2"
+version = "0.4.0"
 description = "MkDocs plugin providing automatic API reference generation"
 dependencies = [
     "mkdocs>=1.4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mkdocs-autoapi"
-version = "0.4.0"
+version = "0.4.1"
 description = "MkDocs plugin providing automatic API reference generation"
 dependencies = [
     "mkdocs>=1.4.0",


### PR DESCRIPTION
### Bug Fixes

- Fixed a bug where the plugin would crash if `nav` is not defined in
`mkdocs.yml` but `autoapi_add_nav_entry` is not `False` (thanks @k4lizen for the
catch!)